### PR TITLE
Dependency debug

### DIFF
--- a/notebooks/workshop.py
+++ b/notebooks/workshop.py
@@ -161,7 +161,7 @@ from Bio.Phylo.TreeConstruction import (
 from Bio.SeqRecord import SeqRecord
 
 # NCBI Datasets: searching and downloading NCBI data
-from ncbi.datasets.openapi import GeneApi
+from ncbi.datasets import GeneApi
 
 # -
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jupytext
 biopython
 matplotlib
-ncbi-datasets-pylib
+ncbi-datasets-pylib~=13.24.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ncbi-datasets-pylib>=11.17,<11.18
+jupytext
 biopython
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jupytext
 biopython
 matplotlib
+ncbi-datasets-pylib


### PR DESCRIPTION
Fix dependency issues that were causing the jupyterhub to crash. The solution was to update ncbi-datasets-pylib.